### PR TITLE
Fix typo in color-name

### DIFF
--- a/riso-colors.json
+++ b/riso-colors.json
@@ -35,7 +35,7 @@
     "zType": "S-4263"
   },
   {
-    "name": "RisoFederal Blue",
+    "name": "Federal Blue",
     "hex": "#3d5588",
     "pantone": "288 U",
     "zType": "S-4265"


### PR DESCRIPTION
While testing my color-name-api I noticed a strange name "risofederal blue". Looks like its wrong in the source data you pulled it from: https://www.stencil.wiki/colors/risofederal-blue

found multiple sources that call it "federal blue":

https://www.ebay.com/itm/324567438083?chn=ps
https://sraofficesolutions.com/index.php/product/risograph-gr1700-2pk-sd-federal-blue-inks-s4395/
https://detako.de/kracka-riso-ink-fii-type-riso-federal-blue-e-s-8124e-1000ml.html

etc.